### PR TITLE
README データベース設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Things you may want to cover:
 
 ### Association
 - has_many :groups, through: :users_groups
+- has_many :users_groups
 - has_many :messages
 
 
@@ -57,6 +58,7 @@ Things you may want to cover:
 
 ### Association
 - has_many :users, through: :users_groups
+- has_many :users_groups
 - has_many :messages
 
 ## users_groupsテーブル

--- a/README.md
+++ b/README.md
@@ -32,30 +32,41 @@ Things you may want to cover:
 |password|string|null: false|
 
 ### Association
-- has_many :groups
+- has_many :groups, through: :users_groups
 - has_many :messages
+
 
 ## messagesテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
+|text|text||
 |image|string||
-|user_id|references ||
-|group_id|references ||
+|user_id|references |null: false, foreign_key: true|
+|group_id|references |null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user
-- has_many :groups
+- belongs_to :group
 
 ## groupsテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
-|user_id|references ||
-|message_id|references ||
+|name|string|null: false|
 
 ### Association
-- has_many :users
+- has_many :users, through: :users_groups
 - has_many :messages
+
+## users_groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|references |null: false, foreign_key: true|
+|group_id|references |null: false, foreign_key: true|
+
+
+### Association
+- belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -22,3 +22,40 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|E-mail|string|null: false, unique: true|
+|password|string|null: false|
+
+### Association
+- has_many :groups
+- has_many :messages
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|image|string||
+|user_id|references ||
+|group_id|references ||
+
+### Association
+- belongs_to :user
+- has_many :groups
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+|user_id|references ||
+|message_id|references ||
+
+### Association
+- has_many :users
+- has_many :messages


### PR DESCRIPTION
# what
chat-spaceで使うデータベースを設計した。
新規登録とログインするために、userテーブルを作って名前とメールアドレス、パスワードを登録できるカラムを作成。
メッセージを送るために文章と画像を登録できるカラムを作成。
チャットグループを作るためにグループ名を登録できるようにした。
# why
データベースを作り登録できるようにしておかないとユーザーの新規登録からチャット、グループ作成が出来ないから。